### PR TITLE
[FIX] Fixes failing TypeScript linting for fibRoute.ts

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,11 +1,12 @@
 // Endpoint for querying the fibonacci numbers
 
+import { Request, Response } from "express";
 import fibonacci from "./fib";
 
-export default (req, res) => {
-  const { num } = req.params;
+export default (req: Request, res: Response) => {
+  const { num } = req.params as { num: string };
 
-  const fibN = fibonacci(parseInt(num));
+  const fibN = fibonacci(parseInt(num)) as number;
   let result = `fibonacci(${num}) is ${fibN}`;
 
   if (fibN < 0) {


### PR DESCRIPTION
# What
- Imports appropriate Request and Response types from express for `res` and `req` variables
- Assigns string type to the `num` member in `req.params`
- Casts return of `fibonacci` as a number
# Test Plan
Confirmed that checks passed on development by running `npm run lint`